### PR TITLE
Fixes issues in assess.peaks.R and extract_tss in Snakemake

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -884,7 +884,7 @@ if config["gtf_file"]:
             if [[ {input.gtf} == *.gz ]]; then
                 zcat {input.gtf} | awk '$3=="gene" && $7=="+" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($4-1)"\\t"$4"\\t"$10"\\t"$6"\\t"$7}} $3=="gene" && $7=="-" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($5-1)"\\t"$5"\\t"$10"\\t"$6"\\t"$7}}' | sed 's/[";]//g' > {output.tss}
             else
-                awk '$3=="gene" && $7=="+" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($4-1)"\\t"$4"\\t"$10"\\t"$6"\\t"$7}} $3=="gene" && $7=="-" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($5-1)"\\t"$5"\\t"$10"\\t"$6"\\t"$7}}' | sed 's/[";]//g' > {output.tss}
+                cat {input.gtf} | awk '$3=="gene" && $7=="+" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($4-1)"\\t"$4"\\t"$10"\\t"$6"\\t"$7}} $3=="gene" && $7=="-" && $0~/gene_type "protein_coding"/ {{print $1"\\t"($5-1)"\\t"$5"\\t"$10"\\t"$6"\\t"$7}}' | sed 's/[";]//g' > {output.tss}
             fi
             """
 

--- a/workflow/scripts/assess_peaks.R
+++ b/workflow/scripts/assess_peaks.R
@@ -131,8 +131,8 @@ for (absname in as.character(snakemake@input[["peaks"]])) {
 df <- left_join(peakF, samplesheet) |>
       select(sampleID, condition, inPeakN) |>
       left_join(stats, by=c("sampleID"="Sample")) |>
-      select(sampleID, condition, inPeakN, MappedFragNum) |>
-      mutate(FRiP = round(inPeakN * 100.0 /MappedFragNum, 2))
+      select(sampleID, condition, inPeakN, UniqueFragNum) |>
+      mutate(FRiP = round(inPeakN * 100.0 /UniqueFragNum, 2))
 df |> write_tsv(as.character(snakemake@output[["peakF"]]))
 
 # GC Content Analysis


### PR DESCRIPTION
This pull request resolves issues reported in #2. It has the following two changes:
1) The FRiP calculation in `assess.peaks.R` uses `UniqueFragNum` instead of `MappedFragNum`.
2) The `extract_tss` rule in Snakemake has `cat {input.gtf} |` added in the `else` block.